### PR TITLE
adds --inherit_env option

### DIFF
--- a/consulconf/main.py
+++ b/consulconf/main.py
@@ -301,6 +301,8 @@ def process_output(ns, kvs, basepath):
     if ns.app:
         apps = ns.app[0].split('+')
         env = dict()
+        if ns.inherit_env:
+            env.update(os.environ)
         [env.update(kvs[app]) for app in apps]
         keys = Counter([keys for app in apps for keys in kvs[app]])
         if any(x > 1 for x in keys.values()):
@@ -402,7 +404,11 @@ build_arg_parser = at.build_arg_parser([
             'Pass a regular expression that selects only the namespaces you'
             ' care to see.  Applies to --dry_run and --puturl, for instance'
         )),
-
+    at.add_argument(
+        '--inherit_env', action='store_true', help=(
+            "Only useful for --app.  If specified, do not remove the"
+            " currently known environment variables available to consulconf"
+            " before spinning up a subshell")),
 ])
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,3 +116,14 @@ def test_option_raw():
             'consulconf -i %s/test-%s --dry_run --raw'
             % (AGENT, fn), shell=True).decode()),
         dct)
+
+
+def test_inherit_env():
+    rv1 = check_output(
+        'INHERITTEST=123 consulconf -i %s --inherit_env --app test/app1 env'
+        % CWD, shell=True).decode()
+    rv2 = check_output(
+        'INHERITTEST=123 consulconf -i %s --app test/app1 env'
+        % CWD, shell=True).decode()
+    nt.assert_true("INHERITTEST=123" in (x.strip() for x in rv1.split()))
+    nt.assert_false("INHERITTEST=123" in (x.strip() for x in rv2.split()))


### PR DESCRIPTION
This option will forward environment variables into the subprocess.
This option only applies if --app is defined

```
A=123 consulconf --app test/app1 env 
```

VS

```
A=123 consulconf --inherit_env --app test/app1 env
```

In the second one, the call to "env" recognizes A=123
